### PR TITLE
Add the .task modifier to view its lifecycle

### DIFF
--- a/ViewLifecycle/LifecycleMonitor.swift
+++ b/ViewLifecycle/LifecycleMonitor.swift
@@ -5,6 +5,7 @@ struct LifecycleMonitor: View {
     var label: String
     @State private var stateTimestamp: Date = .now
     @State private var onAppearTimestamp: Date? = nil
+    @State private var taskStartTimestamp: Date? = nil
     @State private var onDisappearTimestamp: Date? = nil
     @State private var color: Color = .random()
 
@@ -35,6 +36,14 @@ struct LifecycleMonitor: View {
                         .monospacedDigit()
                 }
                 .help("When onDisappear was last called for this view")
+
+                GridRow(alignment: .firstTextBaseline) {
+                    Text("task")
+                    Text(timestampLabel(for: taskStartTimestamp))
+                        .monospacedDigit()
+                }
+                .help("When task was last called for this view")
+
             }
             .font(.callout)
         }
@@ -58,6 +67,14 @@ struct LifecycleMonitor: View {
             let animation: Animation? = onDisappearTimestamp == nil ? nil : .easeOut(duration: 1)
             withAnimation(animation) {
                 onDisappearTimestamp = timestamp
+            }
+        }
+        .task {
+            let timestamp = Date.now
+            print("\(timestamp) \(label): task started")
+            let animation: Animation? = taskStartTimestamp == nil ? nil : .easeOut(duration: 1)
+            withAnimation(animation) {
+                taskStartTimestamp = timestamp
             }
         }
     }


### PR DESCRIPTION
## Reason to Be

While reading up on the `.task` modifier this morning, I wasn't quite sure if its lifecycle exactly matched `.onAppear` and `.onDisappear`. So, I decided to add it to this app and find out.

Related Reading:
* [SwiftUI's .task modifier | Teabyte](https://alexanderweiss.dev/blog/2023-03-05-swiftui-task-modifier)
* [How to run tasks using SwiftUI's task() modifier](https://www.hackingwithswift.com/quick-start/concurrency/how-to-run-tasks-using-swiftuis-task-modifier)

## Thought Process

I considered actually standing up a Task and tracking its lifecycle as well, to show how they are canceled, but decided to keep things very simple. If you'd like me to add that, I can.

## How To Test

Build and run and load up some of the lifecycle views. You should see the new task entry:

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-18 at 10 24 13](https://user-images.githubusercontent.com/170720/226114268-452e8a00-1db2-4d1f-89d6-ebd75efd6c8a.png)


## Possible Impacts

This is fairly straightforward, I don't foresee any adverse effects.